### PR TITLE
Fix timestamp on plugin.json to be in YYYY-MM-DD

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -29,7 +29,7 @@
     ],
     "screenshots": [],
     "version": "0.0.1",
-    "updated": "04-01-2021"
+    "updated": "2021-04-01"
   },
   "dependencies": {
     "grafanaDependency": ">=7.0.0",


### PR DESCRIPTION
This is so that the plugin matches the requirements for the plugin validator.